### PR TITLE
Fixed the bug showing Tuesday's menu on Sundays

### DIFF
--- a/apps/dagsen/views.py
+++ b/apps/dagsen/views.py
@@ -12,7 +12,7 @@ minutes = 10
 def nextMeal():
   now = datetime.datetime.now()
   if now.weekday() < 5 and now.hour > 16:
-    # Weekends and after 16 show next day
+    # after 16 show next day
     return 1
   else:
     # Else show current day

--- a/apps/dagsen/views.py
+++ b/apps/dagsen/views.py
@@ -11,8 +11,8 @@ minutes = 10
 
 def nextMeal():
   now = datetime.datetime.now()
-  if now.hour > 16:
-    # after 16 show next day
+  if now.weekday() < 5 and now.hour > 16:
+    # Weekends and after 16 show next day
     return 1
   else:
     # Else show current day

--- a/apps/dagsen/views.py
+++ b/apps/dagsen/views.py
@@ -11,8 +11,8 @@ minutes = 10
 
 def nextMeal():
   now = datetime.datetime.now()
-  if now.weekday() > 5 or now.hour > 16:
-    # Weekends and after 16 show next day
+  if now.hour > 16:
+    # after 16 show next day
     return 1
   else:
     # Else show current day


### PR DESCRIPTION
Since Saturdays and Sundays are ignored by the API there's no need to add 1 to the current day on the weekends (and the current functionality only works on Sundays, i.e. when datetime.datetime.now().when()==6, resulting in Tuesday's menu on Sunday).
